### PR TITLE
add 알림톡 발송을 위해 신규 크롤링건 리스트 저장

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,9 +15,11 @@ import datetime
 
 app = Flask(__name__)
 Base = declarative_base()
-engine = create_engine('postgresql://jrbysnbvqyvmie:4a2d878446a2864c6c7b9b16b965f58756035fea520bf6f682db34769ff6d053@ec2-44-198-236-169.compute-1.amazonaws.com:5432/db0sh1er7k2vqh')
+engine = create_engine(
+    'postgresql://jrbysnbvqyvmie:4a2d878446a2864c6c7b9b16b965f58756035fea520bf6f682db34769ff6d053@ec2-44-198-236-169.compute-1.amazonaws.com:5432/db0sh1er7k2vqh')
 Session = sessionmaker()
 Session.configure(bind=engine)
+new_crawl_list = []  # 알림 발송할 신규 크롤링 공지 리스트
 
 
 @app.route('/')
@@ -138,130 +140,132 @@ def crawl():
     options = Options()  # 크롤링 옵션
     options.add_argument('headless')  # headless는 화면이나 페이지 이동을 표시하지 않고 동작하는 모드
 
+    new_crawl_list.clear()  # 알림 발송할 신규 크롤링 공지 리스트 : 새로운 것만 들어가야 하므로, 크롤링 실행 전 초기화
+    new_crawl_count = 0  # 신규로 크롤링한 건수 체크
+
     time.sleep(3)  # 검색 결과가 렌더링 될 때까지 잠시 대기
     curPage = 1  # 현재 페이지
     totalPage = 1  # 크롤링할 전체 페이지수
     site_per = 0  # 한 페이지의 게시글 체크용
     loop_index = 0  # 미융대 게시글 관련
 
-
     url_list = [
         [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3646&id=kr_010802000000', '일반공지']
-         , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3638&id=kr_010801000000', '학사공지']
-         , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3654&id=kr_010803000000', '입시공지']
-         , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3662&id=kr_010804000000', '장학공지']
-         , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=9457435&id=kr_010807000000', '국제공지']
-         , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=11533472&id=kr_010808000000', '학술/행사공지']
+        , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3638&id=kr_010801000000', '학사공지']
+        , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3654&id=kr_010803000000', '입시공지']
+        , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=3662&id=kr_010804000000', '장학공지']
+        , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=9457435&id=kr_010807000000', '국제공지']
+        , [0, 'https://www.dongguk.edu/mbs/kr/jsp/board/list.jsp?boardId=11533472&id=kr_010808000000', '학술/행사공지']
 
-         , [1, 'http://bs.dongguk.edu/bbs/board.php?bo_table=bs5_1', '불교학부']
-         , [1, 'http://bs.dongguk.edu/bbs/board.php?bo_table=bs5_3', '불교학부']
-         , [1, 'http://liberal.dongguk.edu/bbs/board.php?bo_table=lib4_1', '문과대학']
-         , [1, 'http://liberal.dongguk.edu/bbs/board.php?bo_table=lib4_3', '문과대학']
-         , [1, 'http://science.dongguk.edu/bbs/board.php?bo_table=sci3_1', '이과대학']
-         , [1, 'http://science.dongguk.edu/bbs/board.php?bo_table=sci3_2', '이과대학']
-         , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_1', '법과대학']
-         , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_3', '법과대학']
-         , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_7', '법과대학']
-         , [1, 'http://social.dongguk.edu/bbs/board.php?bo_table=social3_1', '사회과학대학']
-         , [1, 'http://sba.dongguk.edu/bbs/board.php?bo_table=sba4_1', '경영대학']
-         , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_1', '바이오시스템대학']
-         , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_5', '바이오시스템대학']
-         , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_6', '바이오시스템대학']
-         , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_7', '바이오시스템대학']
-         , [1, 'http://edu.dongguk.edu/bbs/board.php?bo_table=edu3_1', '사범대학']
-         , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1', '사범대학 역사교육과']
-         , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1_2', '사범대학 역사교육과']
-         , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1_3', '사범대학 역사교육과']
-         , [1, 'http://art.dongguk.edu/bbs/board.php?bo_table=art4_1', '예술대학']
-         , [1, 'http://pharm.dongguk.edu/bbs/board.php?bo_table=pharm5_7', '약학대학']
-         , [1, 'http://pharm.dongguk.edu/bbs/board.php?bo_table=pharm5_1', '약학대학']
+        , [1, 'http://bs.dongguk.edu/bbs/board.php?bo_table=bs5_1', '불교학부']
+        , [1, 'http://bs.dongguk.edu/bbs/board.php?bo_table=bs5_3', '불교학부']
+        , [1, 'http://liberal.dongguk.edu/bbs/board.php?bo_table=lib4_1', '문과대학']
+        , [1, 'http://liberal.dongguk.edu/bbs/board.php?bo_table=lib4_3', '문과대학']
+        , [1, 'http://science.dongguk.edu/bbs/board.php?bo_table=sci3_1', '이과대학']
+        , [1, 'http://science.dongguk.edu/bbs/board.php?bo_table=sci3_2', '이과대학']
+        , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_1', '법과대학']
+        , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_3', '법과대학']
+        , [1, 'http://law.dongguk.edu/bbs/board.php?bo_table=law2_7', '법과대학']
+        , [1, 'http://social.dongguk.edu/bbs/board.php?bo_table=social3_1', '사회과학대학']
+        , [1, 'http://sba.dongguk.edu/bbs/board.php?bo_table=sba4_1', '경영대학']
+        , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_1', '바이오시스템대학']
+        , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_5', '바이오시스템대학']
+        , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_6', '바이오시스템대학']
+        , [1, 'http://life.dongguk.edu/bbs/board.php?bo_table=life4_7', '바이오시스템대학']
+        , [1, 'http://edu.dongguk.edu/bbs/board.php?bo_table=edu3_1', '사범대학']
+        , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1', '사범대학 역사교육과']
+        , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1_2', '사범대학 역사교육과']
+        , [1, 'http://historyedu.dongguk.edu/bbs/board.php?bo_table=history6_1_3', '사범대학 역사교육과']
+        , [1, 'http://art.dongguk.edu/bbs/board.php?bo_table=art4_1', '예술대학']
+        , [1, 'http://pharm.dongguk.edu/bbs/board.php?bo_table=pharm5_7', '약학대학']
+        , [1, 'http://pharm.dongguk.edu/bbs/board.php?bo_table=pharm5_1', '약학대학']
 
-         , [2, 'https://kor-cre.dongguk.edu/?page_id=282', '문과대학 국어국문문예창작학부']
-         , [2, 'https://english.dongguk.edu/?page_id=250', '문과대학 영어영문학부']
-         , [2, 'https://english.dongguk.edu/?page_id=259', '문과대학 영어영문학부']
-         , [2, 'https://dj.dongguk.edu/?page_id=203', '문과대학 일본학과']
-         , [2, 'https://dj.dongguk.edu/?page_id=225', '문과대학 일본학과']
-         , [2, 'https://china.dongguk.edu/?page_id=208', '문과대학 중어중문학과']
-         , [2, 'https://sophia.dongguk.edu/?page_id=230', '문과대학 철학과']
-         , [2, 'https://history.dongguk.edu/?page_id=505', '문과대학 사학과']
-         , [2, 'https://chem.dongguk.edu/?page_id=288', '이과대학 화학과']
-         , [2, 'https://stat.dongguk.edu/?page_id=439', '이과대학 통계학과']
-         , [2, 'https://stat.dongguk.edu/?page_id=437', '이과대학 통계학과']
-         , [2, 'https://math.dongguk.edu/?page_id=260', '이과대학 수학과']
-         , [2, 'https://physics.dongguk.edu/?page_id=324', '이과대학 물리반도체과학부']
-         , [2, 'https://physics.dongguk.edu/?page_id=326', '이과대학 물리반도체과학부']
-         , [2, 'https://politics.dongguk.edu/?page_id=18518', '사회과학대학 정치외교학과']
-         , [2, 'https://politics.dongguk.edu/?page_id=18522', '사회과학대학 정치외교학과']
-         , [2, 'https://pa.dongguk.edu/?page_id=233', '사회과학대학 행정학과']
-         , [2, 'https://nk.dongguk.edu/?page_id=225', '사회과학대학 북한학과']
-         , [2, 'https://econ.dongguk.edu/?page_id=262', '사회과학대학 경제학과']
-         , [2, 'https://econ.dongguk.edu/?page_id=297', '사회과학대학 경제학과']
-         , [2, 'http://itrade.dongguk.edu/?page_id=150', '사회과학대학 국제통상학과']
-         , [2, 'https://sociology.dongguk.edu/?page_id=211', '사회과학대학 사회학과']
-         , [2, 'https://welfare.dongguk.edu/?page_id=209', '사회과학대학 사회복지학과']
-         , [2, 'https://police.dongguk.edu/?page_id=18349', '경찰사법대학 경찰행정학부']
-         , [2, 'https://mgt.dongguk.edu/?page_id=18326', '경영대학 경영학과']
-         , [2, 'https://acc.dongguk.edu/?page_id=18334', '경영대학 회계학과']
-         , [2, 'https://acc.dongguk.edu/?page_id=1087707', '경영대학 회계학과']
-         , [2, 'https://acc.dongguk.edu/?page_id=18328', '경영대학 회계학과']
-         , [2, 'http://mis.dongguk.edu/?page_id=269', '경영대학 경영정보학과']
-         , [2, 'https://bio.dongguk.edu/?page_id=18531', '바이오시스템대학 바이오환경과학과']
-         , [2, 'https://lifescience.dongguk.edu/?page_id=150', '바이오시스템대학 생명과학과']
-         , [2, 'https://food.dongguk.edu/?page_id=243', '바이오시스템대학 식품생명공학과']
-         , [2, 'http://mbt.dongguk.edu/?page_id=241', '바이오시스템대학 의생명공학과']
-         , [2, 'https://civil.dongguk.edu/?page_id=269', '공과대학 건설환경공학과']
-         , [2, 'https://civil.dongguk.edu/?page_id=271', '공과대학 건설환경공학과']
-         , [2, 'https://civil.dongguk.edu/?page_id=273', '공과대학 건설환경공학과']
-         , [2, 'https://civil.dongguk.edu/?page_id=277', '공과대학 건설환경공학과']
-         , [2, 'https://archi.dongguk.edu/?page_id=18387', '공과대학 건축공학부']
-         , [2, 'https://archi.dongguk.edu/?page_id=18394', '공과대학 건축공학부']
-         , [2, 'https://mecha.dongguk.edu/?page_id=207', '공과대학 기계로봇에너지공학과']
-         , [2, 'https://mecha.dongguk.edu/?page_id=332', '공과대학 기계로봇에너지공학과']
-         , [2, 'https://me.dongguk.edu/?page_id=249', '공과대학 융합에너지신소재공학과']
-         , [2, 'https://dee.dongguk.edu/?page_id=553', '공과대학 전자전기공학부']
-         , [2, 'https://dee.dongguk.edu/?page_id=555', '공과대학 전자전기공학부']
-         , [2, 'https://dee.dongguk.edu/?page_id=557', '공과대학 전자전기공학부']
-         , [2, 'https://ice.dongguk.edu/?page_id=18518', '공과대학 정보통신공학전공']
-         , [2, 'https://cse.dongguk.edu/?page_id=799', '공과대학 컴퓨터공학전공']
-         , [2, 'https://cse.dongguk.edu/?page_id=827', '공과대학 컴퓨터공학전공']
-         , [2, 'https://chembioeng.dongguk.edu/?page_id=207', '공과대학 화공생물공학과']
-         , [2, 'https://chembioeng.dongguk.edu/?page_id=83742', '공과대학 화공생물공학과']
-         , [2, 'https://education.dongguk.edu/?page_id=230', '사범대학 교육학과']
-         , [2, 'https://duce.dongguk.edu/?page_id=245', '사범대학 국어교육과']
-         , [2, 'https://geoedu.dongguk.edu/?page_id=148', '사범대학 지리교육과']
-         , [2, 'https://dume.dongguk.edu/?page_id=223', '사범대학 수학교육과']
-         , [2, 'https://homeedu.dongguk.edu/?page_id=211', '사범대학 가정교육과']
-         , [2, 'https://pe.dongguk.edu/?page_id=230', '사범대학 체육교육과']
-         , [2, 'https://theatre.dongguk.edu/?page_id=391', '예술대학 연극학부']
+        , [2, 'https://kor-cre.dongguk.edu/?page_id=282', '문과대학 국어국문문예창작학부']
+        , [2, 'https://english.dongguk.edu/?page_id=250', '문과대학 영어영문학부']
+        , [2, 'https://english.dongguk.edu/?page_id=259', '문과대학 영어영문학부']
+        , [2, 'https://dj.dongguk.edu/?page_id=203', '문과대학 일본학과']
+        , [2, 'https://dj.dongguk.edu/?page_id=225', '문과대학 일본학과']
+        , [2, 'https://china.dongguk.edu/?page_id=208', '문과대학 중어중문학과']
+        , [2, 'https://sophia.dongguk.edu/?page_id=230', '문과대학 철학과']
+        , [2, 'https://history.dongguk.edu/?page_id=505', '문과대학 사학과']
+        , [2, 'https://chem.dongguk.edu/?page_id=288', '이과대학 화학과']
+        , [2, 'https://stat.dongguk.edu/?page_id=439', '이과대학 통계학과']
+        , [2, 'https://stat.dongguk.edu/?page_id=437', '이과대학 통계학과']
+        , [2, 'https://math.dongguk.edu/?page_id=260', '이과대학 수학과']
+        , [2, 'https://physics.dongguk.edu/?page_id=324', '이과대학 물리반도체과학부']
+        , [2, 'https://physics.dongguk.edu/?page_id=326', '이과대학 물리반도체과학부']
+        , [2, 'https://politics.dongguk.edu/?page_id=18518', '사회과학대학 정치외교학과']
+        , [2, 'https://politics.dongguk.edu/?page_id=18522', '사회과학대학 정치외교학과']
+        , [2, 'https://pa.dongguk.edu/?page_id=233', '사회과학대학 행정학과']
+        , [2, 'https://nk.dongguk.edu/?page_id=225', '사회과학대학 북한학과']
+        , [2, 'https://econ.dongguk.edu/?page_id=262', '사회과학대학 경제학과']
+        , [2, 'https://econ.dongguk.edu/?page_id=297', '사회과학대학 경제학과']
+        , [2, 'http://itrade.dongguk.edu/?page_id=150', '사회과학대학 국제통상학과']
+        , [2, 'https://sociology.dongguk.edu/?page_id=211', '사회과학대학 사회학과']
+        , [2, 'https://welfare.dongguk.edu/?page_id=209', '사회과학대학 사회복지학과']
+        , [2, 'https://police.dongguk.edu/?page_id=18349', '경찰사법대학 경찰행정학부']
+        , [2, 'https://mgt.dongguk.edu/?page_id=18326', '경영대학 경영학과']
+        , [2, 'https://acc.dongguk.edu/?page_id=18334', '경영대학 회계학과']
+        , [2, 'https://acc.dongguk.edu/?page_id=1087707', '경영대학 회계학과']
+        , [2, 'https://acc.dongguk.edu/?page_id=18328', '경영대학 회계학과']
+        , [2, 'http://mis.dongguk.edu/?page_id=269', '경영대학 경영정보학과']
+        , [2, 'https://bio.dongguk.edu/?page_id=18531', '바이오시스템대학 바이오환경과학과']
+        , [2, 'https://lifescience.dongguk.edu/?page_id=150', '바이오시스템대학 생명과학과']
+        , [2, 'https://food.dongguk.edu/?page_id=243', '바이오시스템대학 식품생명공학과']
+        , [2, 'http://mbt.dongguk.edu/?page_id=241', '바이오시스템대학 의생명공학과']
+        , [2, 'https://civil.dongguk.edu/?page_id=269', '공과대학 건설환경공학과']
+        , [2, 'https://civil.dongguk.edu/?page_id=271', '공과대학 건설환경공학과']
+        , [2, 'https://civil.dongguk.edu/?page_id=273', '공과대학 건설환경공학과']
+        , [2, 'https://civil.dongguk.edu/?page_id=277', '공과대학 건설환경공학과']
+        , [2, 'https://archi.dongguk.edu/?page_id=18387', '공과대학 건축공학부']
+        , [2, 'https://archi.dongguk.edu/?page_id=18394', '공과대학 건축공학부']
+        , [2, 'https://mecha.dongguk.edu/?page_id=207', '공과대학 기계로봇에너지공학과']
+        , [2, 'https://mecha.dongguk.edu/?page_id=332', '공과대학 기계로봇에너지공학과']
+        , [2, 'https://me.dongguk.edu/?page_id=249', '공과대학 융합에너지신소재공학과']
+        , [2, 'https://dee.dongguk.edu/?page_id=553', '공과대학 전자전기공학부']
+        , [2, 'https://dee.dongguk.edu/?page_id=555', '공과대학 전자전기공학부']
+        , [2, 'https://dee.dongguk.edu/?page_id=557', '공과대학 전자전기공학부']
+        , [2, 'https://ice.dongguk.edu/?page_id=18518', '공과대학 정보통신공학전공']
+        , [2, 'https://cse.dongguk.edu/?page_id=799', '공과대학 컴퓨터공학전공']
+        , [2, 'https://cse.dongguk.edu/?page_id=827', '공과대학 컴퓨터공학전공']
+        , [2, 'https://chembioeng.dongguk.edu/?page_id=207', '공과대학 화공생물공학과']
+        , [2, 'https://chembioeng.dongguk.edu/?page_id=83742', '공과대학 화공생물공학과']
+        , [2, 'https://education.dongguk.edu/?page_id=230', '사범대학 교육학과']
+        , [2, 'https://duce.dongguk.edu/?page_id=245', '사범대학 국어교육과']
+        , [2, 'https://geoedu.dongguk.edu/?page_id=148', '사범대학 지리교육과']
+        , [2, 'https://dume.dongguk.edu/?page_id=223', '사범대학 수학교육과']
+        , [2, 'https://homeedu.dongguk.edu/?page_id=211', '사범대학 가정교육과']
+        , [2, 'https://pe.dongguk.edu/?page_id=230', '사범대학 체육교육과']
+        , [2, 'https://theatre.dongguk.edu/?page_id=391', '예술대학 연극학부']
 
-         , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5', '사회과학대학 미디어커뮤니케이션학과']
-         , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5_1', '사회과학대학 미디어커뮤니케이션학과']
-         , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5_2', '사회과학대학 미디어커뮤니케이션학과']
+        , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5', '사회과학대학 미디어커뮤니케이션학과']
+        , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5_1', '사회과학대학 미디어커뮤니케이션학과']
+        , [3, 'https://comm.dongguk.edu/gnuboard4/bbs/board.php?bo_table=2_5_2', '사회과학대학 미디어커뮤니케이션학과']
 
-         , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table38', '사회과학대학 식품산업관리학과']
-         , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table39', '사회과학대학 식품산업관리학과']
-         , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table40', '사회과학대학 식품산업관리학과']
+        , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table38', '사회과학대학 식품산업관리학과']
+        , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table39', '사회과학대학 식품산업관리학과']
+        , [4, 'http://www.donggukfoodindus-edu.com/bbs/board.php?bo_table=table40', '사회과학대학 식품산업관리학과']
 
-         , [5, 'http://dguadpr.kr/bbs/board.php?bo_table=table31', '사회과학대학 광고홍보학과']
-         , [5, 'http://dguadpr.kr/bbs/board.php?bo_table=table40', '사회과학대학 광고홍보학과']
-         , [5, 'http://justice.dongguk.edu/bbs/board.php?bo_table=justice7_1', '경찰사법대학']
-         , [5, 'https://movie.dongguk.edu/bbs/board.php?bo_table=movie1_3_1', '예술대학 영화영상학과']
+        , [5, 'http://dguadpr.kr/bbs/board.php?bo_table=table31', '사회과학대학 광고홍보학과']
+        , [5, 'http://dguadpr.kr/bbs/board.php?bo_table=table40', '사회과학대학 광고홍보학과']
+        , [5, 'http://justice.dongguk.edu/bbs/board.php?bo_table=justice7_1', '경찰사법대학']
+        , [5, 'https://movie.dongguk.edu/bbs/board.php?bo_table=movie1_3_1', '예술대학 영화영상학과']
 
-         , [6, 'https://security.dongguk.edu/bbs/data/list.do?menu_idx=30', '미래융합대학 융합보안학과']
-         , [6, 'https://swc.dongguk.edu/bbs/data/list.do?menu_idx=46', '미래융합대학 사회복지상담학과']
-         , [6, 'https://gt.dongguk.edu/bbs/data/list.do?menu_idx=58', '미래융합대학 글로벌무역학과']
+        , [6, 'https://security.dongguk.edu/bbs/data/list.do?menu_idx=30', '미래융합대학 융합보안학과']
+        , [6, 'https://swc.dongguk.edu/bbs/data/list.do?menu_idx=46', '미래융합대학 사회복지상담학과']
+        , [6, 'https://gt.dongguk.edu/bbs/data/list.do?menu_idx=58', '미래융합대학 글로벌무역학과']
 
-         , [7, 'http://engineer.dongguk.edu/en5_1', '공과대학']
+        , [7, 'http://engineer.dongguk.edu/en5_1', '공과대학']
 
-         , [8, 'http://mme.dongguk.edu/k3/sub5/sub1.php?tsort=51&msort=62', '공과대학 멀티미디어공학과']
+        , [8, 'http://mme.dongguk.edu/k3/sub5/sub1.php?tsort=51&msort=62', '공과대학 멀티미디어공학과']
 
-         , [9, 'https://fc.dongguk.edu/bbs/data/list.do?menu_idx=12', '미래융합대학']
+        , [9, 'https://fc.dongguk.edu/bbs/data/list.do?menu_idx=12', '미래융합대학']
 
-         , [10, 'https://ai.dongguk.edu/aix6_1', 'AI 융합학부']
+        , [10, 'https://ai.dongguk.edu/aix6_1', 'AI 융합학부']
 
-         , [11, 'http://ise.dongguk.edu/bbs/board.php?bo_table=ise6_1', '공과대학 산업시스템공학과']
-         , [11, 'http://ise.dongguk.edu/bbs/board.php?bo_table=ise8_7', '공과대학 산업시스템공학과']
-         , [2, 'https://me.dongguk.edu/?page_id=218', '공과대학 융합에너지신소재공학과']
+        , [11, 'http://ise.dongguk.edu/bbs/board.php?bo_table=ise6_1', '공과대학 산업시스템공학과']
+        , [11, 'http://ise.dongguk.edu/bbs/board.php?bo_table=ise8_7', '공과대학 산업시스템공학과']
+        , [2, 'https://me.dongguk.edu/?page_id=218', '공과대학 융합에너지신소재공학과']
     ]
 
     # 사이트마다 페이징을 위한 변수가 다름.
@@ -405,9 +409,18 @@ def crawl():
                     # DB에 저장
                     results = session.query(Crawl.link).filter_by(category=category, link=link).all()
                     if not results:
-                        session.add(Crawl(category=category, title=name, link=link, crawl_time=datetime.datetime.now()))
+                        now_time = str(datetime.datetime.now())
+                        session.add(Crawl(category=category, title=name, link=link, crawl_time=now_time))
                         session.commit()
                         print('성공 : [' + category + ']' + name + ' >> ' + link)
+
+                        # new_crawl_list를 2차원 형태로 만들어서 신규 크롤링 데이터 추가
+                        new_crawl_list.append([])
+                        new_crawl_list[new_crawl_count].append(category)
+                        new_crawl_list[new_crawl_count].append(name.replace("\xa0", " "))
+                        new_crawl_list[new_crawl_count].append(link)
+                        new_crawl_list[new_crawl_count].append(now_time)
+                        new_crawl_count += 1
                     else:
                         print('     실패 : [' + category + ']' + name + ' >> ' + link)
 


### PR DESCRIPTION
- 알림톡 발송하기 위해서, 신규 크롤링 건을 리스트에 저장.
- new_crawl_list는 2차원 리스트 형태이며, 한시간마다 크롤링 실행 시 초기화 되어 신규 건들만 저장 됨.
- new_crawl_list의 공지 제목을 토큰화
 → 토큰화된 각단어들의 유사단어 모두 추출
  → 유사 단어 + 토큰화 된 단어 를 가지고 있는 유저에게 알림 발송